### PR TITLE
Updated fieldParser arguments to be optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,12 @@ export interface fieldsParserProps {
   include: number;
 }
 
-export function fieldsParser(data: any, props: fieldsParserProps): any;
+export interface fieldParserOptions {
+  parseArrays?: boolean;
+  parseRefs?: boolean;
+}
+
+export function fieldsParser(data: any, props?: fieldsParserProps, options?: fieldParserOptions): any;
 
 /**
  *  graphqlParser


### PR DESCRIPTION
## Summary
Since there are already default values defined for [`props`](https://github.com/ryanhefner/contentful-parsers/blob/master/src/parsers/fieldsParser.js#L10) and [`options`](https://github.com/ryanhefner/contentful-parsers/blob/master/src/parsers/fieldsParser.js#L11), there's no need to require them.

![image](https://user-images.githubusercontent.com/6789067/94736996-f8ecba80-0321-11eb-8035-7d8b9fd7c2a7.png)

## Changes
Updated the `props` and `options` in `fieldsParser` types to be optional. 

## Notes
Awesome package btw, going to reduce our overall file size significantly! 😄 